### PR TITLE
Add more prereqs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Tested on a host running Ubuntu 20.04.1.
 - Utilities required:
     - ```p7zip-full```
     - ```mkisofs``` or ```genisoimage```
+    - ```xorriso```
+    - ```curl```
+    - ```isolinux```
 
 ### Usage
 ```


### PR DESCRIPTION
Current list of prerequisites is incomplete for a fresh install of Ubuntu 20.04. This fixes it. 